### PR TITLE
add PR validation workflow (format, lint, tests)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,33 @@
+name: PR validation
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: pr-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.13'
+          cache: npm
+
+      - run: npm ci
+
+      - name: Prettier
+        run: npm run format:check
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm test


### PR DESCRIPTION
## Summary
- New `.github/workflows/pr.yml` runs on every PR targeting `main`.
- Steps: `npm ci` → `npm run format:check` → `npm run lint` → `npm test`.
- Concurrency group cancels superseded runs on the same PR so a fast push doesn't queue stale work.
- Pinned to Node 22.13 — matches the engine requirement that surfaced as an `npm EBADENGINE` warning on older 22.x during the previous PR.

## Test plan
- [ ] Workflow runs on this PR itself and all three steps go green.
- [ ] Force a failure locally (e.g. unformatted file) and confirm `format:check` would fail the job (sanity check, not part of merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)