### PR TITLE
rename GameEvent.kind → .type and Effect.kind → .type (#73)

### DIFF
--- a/apps/engine-server/src/repl/index.ts
+++ b/apps/engine-server/src/repl/index.ts
@@ -105,7 +105,7 @@ const printIncoming = (msg: ServerMessage): void => {
         } else if ('playerId' in e) {
           summary = ` ${(e as { playerId: string }).playerId}`;
         }
-        console.log(`   · ${e.kind}${summary}`);
+        console.log(`   · ${e.type}${summary}`);
       }
       return;
     case 'rejected_action':
@@ -323,7 +323,7 @@ const main = async (): Promise<void> => {
           targetPlayer = opts.target as PlayerId;
         }
         const targets = (def.effects ?? [])
-          .filter((e) => e.kind === 'deal_damage_to_any')
+          .filter((e) => e.type === 'deal_damage_to_any')
           .map(() => ({ kind: 'player' as const, playerId: targetPlayer }));
         const type = def.types.includes('instant')
           ? ActionType.CastInstant

--- a/libs/engine-core/src/lib/cards/catalog/healing-salve.ts
+++ b/libs/engine-core/src/lib/cards/catalog/healing-salve.ts
@@ -10,5 +10,5 @@ export const healingSalve: CardDefinition = {
   manaCost: { W: 1 },
   cmc: 1,
   keywords: [],
-  effects: [{ kind: 'gain_life', amount: 3 }],
+  effects: [{ type: 'gain_life', amount: 3 }],
 };

--- a/libs/engine-core/src/lib/cards/catalog/lightning-bolt.ts
+++ b/libs/engine-core/src/lib/cards/catalog/lightning-bolt.ts
@@ -10,5 +10,5 @@ export const lightningBolt: CardDefinition = {
   manaCost: { R: 1 },
   cmc: 1,
   keywords: [],
-  effects: [{ kind: 'deal_damage_to_any', amount: 3 }],
+  effects: [{ type: 'deal_damage_to_any', amount: 3 }],
 };

--- a/libs/engine-core/src/lib/cards/catalog/lightning-strike.ts
+++ b/libs/engine-core/src/lib/cards/catalog/lightning-strike.ts
@@ -10,5 +10,5 @@ export const lightningStrike: CardDefinition = {
   manaCost: { R: 1, generic: 1 },
   cmc: 2,
   keywords: [],
-  effects: [{ kind: 'deal_damage_to_any', amount: 3 }],
+  effects: [{ type: 'deal_damage_to_any', amount: 3 }],
 };

--- a/libs/engine-core/src/lib/cards/effects/effect-registry.ts
+++ b/libs/engine-core/src/lib/cards/effects/effect-registry.ts
@@ -3,7 +3,7 @@ import { err, ok } from '@mtg-utils/engine-util';
 import type { GameEvent } from '../../engine/events';
 import type { GameState } from '../../model/game-state';
 import type { CardInstanceId, PlayerId } from '../../model/types';
-import type { Effect, EffectKind, EffectTarget } from './effect-types';
+import type { Effect, EffectTarget, EffectType } from './effect-types';
 import { dealDamageToAny } from './handlers/deal-damage';
 import { drawCards } from './handlers/draw-cards';
 import { gainLife } from './handlers/gain-life';
@@ -22,15 +22,15 @@ export type EffectHandler<E extends Effect> = (
 
 type AnyHandler = EffectHandler<Effect>;
 
-const registry = new Map<EffectKind, AnyHandler>([
+const registry = new Map<EffectType, AnyHandler>([
   ['deal_damage_to_any', dealDamageToAny as AnyHandler],
   ['draw_cards', drawCards as AnyHandler],
   ['gain_life', gainLife as AnyHandler],
 ]);
 
 export const runEffect = (effect: Effect, ctx: EffectContext): Result<GameEvent[], string> => {
-  const handler = registry.get(effect.kind);
-  if (!handler) return err(`no handler registered for effect ${effect.kind}`);
+  const handler = registry.get(effect.type);
+  if (!handler) return err(`no handler registered for effect ${effect.type}`);
   return handler(effect, ctx);
 };
 

--- a/libs/engine-core/src/lib/cards/effects/effect-types.ts
+++ b/libs/engine-core/src/lib/cards/effects/effect-types.ts
@@ -5,20 +5,20 @@ export type EffectTarget =
   | { kind: 'permanent'; cardId: CardInstanceId };
 
 export type DealDamageToAny = {
-  kind: 'deal_damage_to_any';
+  type: 'deal_damage_to_any';
   amount: number;
 };
 
 export type DrawCards = {
-  kind: 'draw_cards';
+  type: 'draw_cards';
   count: number;
 };
 
 export type GainLife = {
-  kind: 'gain_life';
+  type: 'gain_life';
   amount: number;
 };
 
 export type Effect = DealDamageToAny | DrawCards | GainLife;
 
-export type EffectKind = Effect['kind'];
+export type EffectType = Effect['type'];

--- a/libs/engine-core/src/lib/cards/effects/handlers/deal-damage.ts
+++ b/libs/engine-core/src/lib/cards/effects/handlers/deal-damage.ts
@@ -15,7 +15,7 @@ export const dealDamageToAny: EffectHandler<DealDamageToAny> = (effect, ctx: Eff
   }
   const events: GameEvent[] = [
     {
-      kind: 'damage_dealt',
+      type: 'damage_dealt',
       sourceCardId: ctx.sourceCardId,
       target,
       amount: effect.amount,
@@ -24,7 +24,7 @@ export const dealDamageToAny: EffectHandler<DealDamageToAny> = (effect, ctx: Eff
   ];
   if (target.kind === 'player') {
     events.push({
-      kind: 'life_changed',
+      type: 'life_changed',
       playerId: target.playerId,
       delta: -effect.amount,
       reason: 'damage',

--- a/libs/engine-core/src/lib/cards/effects/handlers/draw-cards.ts
+++ b/libs/engine-core/src/lib/cards/effects/handlers/draw-cards.ts
@@ -9,10 +9,10 @@ export const drawCards: EffectHandler<DrawCards> = (effect, ctx) => {
   for (let i = 0; i < effect.count; i++) {
     const cardId = library[i];
     if (cardId === undefined) {
-      events.push({ kind: 'draw_attempted_empty', playerId: ctx.casterId });
+      events.push({ type: 'draw_attempted_empty', playerId: ctx.casterId });
       break;
     }
-    events.push({ kind: 'card_drawn', playerId: ctx.casterId, cardId });
+    events.push({ type: 'card_drawn', playerId: ctx.casterId, cardId });
   }
   return ok(events);
 };

--- a/libs/engine-core/src/lib/cards/effects/handlers/gain-life.ts
+++ b/libs/engine-core/src/lib/cards/effects/handlers/gain-life.ts
@@ -5,7 +5,7 @@ import type { GainLife } from '../effect-types';
 export const gainLife: EffectHandler<GainLife> = (effect, ctx) =>
   ok([
     {
-      kind: 'life_changed',
+      type: 'life_changed',
       playerId: ctx.casterId,
       delta: effect.amount,
       reason: 'effect',

--- a/libs/engine-core/src/lib/engine/apply-event.ts
+++ b/libs/engine-core/src/lib/engine/apply-event.ts
@@ -49,7 +49,7 @@ const nextStep = (current: Step): { step: Step; wraps: boolean } => {
 };
 
 export const applyEvent = (state: GameState, event: GameEvent): GameState => {
-  switch (event.kind) {
+  switch (event.type) {
     case 'card_entered_zone': {
       const card = state.cards[event.cardId];
       const owner = state.players[card.ownerId];

--- a/libs/engine-core/src/lib/engine/engine.spec.ts
+++ b/libs/engine-core/src/lib/engine/engine.spec.ts
@@ -273,7 +273,7 @@ describe('engine', () => {
 
     // Drive a card_drawn event directly. Choose the top of the library.
     const drawnId = state.players[active].library[0]!;
-    const result = engine.drain(state, [{ kind: 'card_drawn', playerId: active, cardId: drawnId }]);
+    const result = engine.drain(state, [{ type: 'card_drawn', playerId: active, cardId: drawnId }]);
     expect(result.state.cards[drawnId].zone).toBe('hand');
     expect(result.state.players[active].hand).toContain(drawnId);
 

--- a/libs/engine-core/src/lib/engine/event-bus.ts
+++ b/libs/engine-core/src/lib/engine/event-bus.ts
@@ -1,26 +1,26 @@
 import type { GameState } from '../model/game-state';
-import type { GameEvent, GameEventKind } from './events';
+import type { GameEvent, GameEventType } from './events';
 
 export type Subscriber = (state: GameState, event: GameEvent) => GameEvent[];
 
 export type EventBus = {
-  on: (kind: GameEventKind | '*', handler: Subscriber) => void;
+  on: (eventType: GameEventType | '*', handler: Subscriber) => void;
   notify: (state: GameState, event: GameEvent) => GameEvent[];
 };
 
 export const createEventBus = (): EventBus => {
-  const byKind = new Map<GameEventKind | '*', Subscriber[]>();
+  const byType = new Map<GameEventType | '*', Subscriber[]>();
 
-  const on: EventBus['on'] = (kind, handler) => {
-    const existing = byKind.get(kind);
+  const on: EventBus['on'] = (eventType, handler) => {
+    const existing = byType.get(eventType);
     if (existing) existing.push(handler);
-    else byKind.set(kind, [handler]);
+    else byType.set(eventType, [handler]);
   };
 
   const notify: EventBus['notify'] = (state, event) => {
     const out: GameEvent[] = [];
-    for (const handler of byKind.get(event.kind) ?? []) out.push(...handler(state, event));
-    for (const handler of byKind.get('*') ?? []) out.push(...handler(state, event));
+    for (const handler of byType.get(event.type) ?? []) out.push(...handler(state, event));
+    for (const handler of byType.get('*') ?? []) out.push(...handler(state, event));
     return out;
   };
 

--- a/libs/engine-core/src/lib/engine/events.ts
+++ b/libs/engine-core/src/lib/engine/events.ts
@@ -2,7 +2,7 @@ import type { StackItem } from '../model/stack';
 import type { CardInstanceId, ManaColor, PlayerId, StackItemId, Step, Zone } from '../model/types';
 
 export type CardEnteredZone = {
-  kind: 'card_entered_zone';
+  type: 'card_entered_zone';
   cardId: CardInstanceId;
   from: Zone;
   to: Zone;
@@ -10,17 +10,17 @@ export type CardEnteredZone = {
 };
 
 export type PermanentTapped = {
-  kind: 'permanent_tapped';
+  type: 'permanent_tapped';
   cardId: CardInstanceId;
 };
 
 export type PermanentUntapped = {
-  kind: 'permanent_untapped';
+  type: 'permanent_untapped';
   cardId: CardInstanceId;
 };
 
 export type ManaProduced = {
-  kind: 'mana_produced';
+  type: 'mana_produced';
   playerId: PlayerId;
   color: ManaColor;
   amount: number;
@@ -28,18 +28,18 @@ export type ManaProduced = {
 };
 
 export type ManaSpent = {
-  kind: 'mana_spent';
+  type: 'mana_spent';
   playerId: PlayerId;
   spent: Partial<Record<ManaColor, number>>;
 };
 
 export type ManaPoolEmptied = {
-  kind: 'mana_pool_emptied';
+  type: 'mana_pool_emptied';
   playerId: PlayerId;
 };
 
 export type DamageDealt = {
-  kind: 'damage_dealt';
+  type: 'damage_dealt';
   sourceCardId: CardInstanceId;
   target: { kind: 'player'; playerId: PlayerId } | { kind: 'permanent'; cardId: CardInstanceId };
   amount: number;
@@ -47,108 +47,108 @@ export type DamageDealt = {
 };
 
 export type LifeChanged = {
-  kind: 'life_changed';
+  type: 'life_changed';
   playerId: PlayerId;
   delta: number;
   reason: 'damage' | 'lifelink' | 'effect';
 };
 
 export type CardDrawn = {
-  kind: 'card_drawn';
+  type: 'card_drawn';
   playerId: PlayerId;
   cardId: CardInstanceId;
 };
 
 export type DrawAttemptedEmpty = {
-  kind: 'draw_attempted_empty';
+  type: 'draw_attempted_empty';
   playerId: PlayerId;
 };
 
 export type LandPlayed = {
-  kind: 'land_played';
+  type: 'land_played';
   playerId: PlayerId;
   cardId: CardInstanceId;
 };
 
 export type SpellPutOnStack = {
-  kind: 'spell_put_on_stack';
+  type: 'spell_put_on_stack';
   item: StackItem;
 };
 
 export type StackItemResolved = {
-  kind: 'stack_item_resolved';
+  type: 'stack_item_resolved';
   stackItemId: StackItemId;
 };
 
 export type PriorityPassed = {
-  kind: 'priority_passed';
+  type: 'priority_passed';
   from: PlayerId;
   to: PlayerId;
 };
 
 export type PriorityReset = {
-  kind: 'priority_reset';
+  type: 'priority_reset';
   to: PlayerId;
   /** Why priority was reset (state change on stack, step transition). */
   reason: 'stack_changed' | 'step_started';
 };
 
 export type CreatureDied = {
-  kind: 'creature_died';
+  type: 'creature_died';
   cardId: CardInstanceId;
 };
 
 export type AttackerDeclared = {
-  kind: 'attacker_declared';
+  type: 'attacker_declared';
   attackerId: CardInstanceId;
   defenderId: PlayerId;
 };
 
 export type BlockerDeclared = {
-  kind: 'blocker_declared';
+  type: 'blocker_declared';
   blockerId: CardInstanceId;
   attackerId: CardInstanceId;
 };
 
 export type CombatDamageMarked = {
-  kind: 'combat_damage_marked';
+  type: 'combat_damage_marked';
 };
 
 export type DamageClearedAtCleanup = {
-  kind: 'damage_cleared_at_cleanup';
+  type: 'damage_cleared_at_cleanup';
 };
 
 export type SummoningSicknessCleared = {
-  kind: 'summoning_sickness_cleared';
+  type: 'summoning_sickness_cleared';
   cardId: CardInstanceId;
 };
 
 export type StepAdvanced = {
-  kind: 'step_advanced';
+  type: 'step_advanced';
   from: Step;
   to: Step;
   turn: number;
 };
 
 export type TurnStarted = {
-  kind: 'turn_started';
+  type: 'turn_started';
   turn: number;
   activePlayer: PlayerId;
 };
 
 export type LandsPlayedReset = {
-  kind: 'lands_played_reset';
+  type: 'lands_played_reset';
   playerId: PlayerId;
 };
 
 export type PlayerLost = {
-  kind: 'player_lost';
+  type: 'player_lost';
   playerId: PlayerId;
   reason: 'life' | 'deck_out' | 'concede';
 };
 
 export type GameEnded = {
-  kind: 'game_ended';
+  type: 'game_ended';
   winner: PlayerId | null;
 };
 
@@ -180,4 +180,4 @@ export type GameEvent =
   | PlayerLost
   | GameEnded;
 
-export type GameEventKind = GameEvent['kind'];
+export type GameEventType = GameEvent['type'];

--- a/libs/engine-core/src/lib/engine/phases/advance-step.ts
+++ b/libs/engine-core/src/lib/engine/phases/advance-step.ts
@@ -23,12 +23,12 @@ const intrinsicForStep = (state: GameState, step: Step): GameEvent[] => {
 const intrinsicUntap = (state: GameState): GameEvent[] => {
   const active = state.activePlayer;
   const events: GameEvent[] = [];
-  events.push({ kind: 'lands_played_reset', playerId: active });
+  events.push({ type: 'lands_played_reset', playerId: active });
   for (const id of state.battlefield) {
     const c = state.cards[id];
     if (c.controllerId !== active) continue;
-    if (c.tapped) events.push({ kind: 'permanent_untapped', cardId: id });
-    if (c.summoningSick) events.push({ kind: 'summoning_sickness_cleared', cardId: id });
+    if (c.tapped) events.push({ type: 'permanent_untapped', cardId: id });
+    if (c.summoningSick) events.push({ type: 'summoning_sickness_cleared', cardId: id });
   }
   return events;
 };
@@ -40,19 +40,19 @@ const intrinsicDraw = (state: GameState): GameEvent[] => {
   const lib = state.players[active].library;
   if (lib.length === 0) {
     return [
-      { kind: 'draw_attempted_empty', playerId: active },
-      { kind: 'player_lost', playerId: active, reason: 'deck_out' },
+      { type: 'draw_attempted_empty', playerId: active },
+      { type: 'player_lost', playerId: active, reason: 'deck_out' },
     ];
   }
-  return [{ kind: 'card_drawn', playerId: active, cardId: lib[0] as CardInstanceId }];
+  return [{ type: 'card_drawn', playerId: active, cardId: lib[0] as CardInstanceId }];
 };
 
 const intrinsicCleanup = (state: GameState): GameEvent[] => {
   const events: GameEvent[] = [];
   for (const pid of state.playerOrder) {
-    events.push({ kind: 'mana_pool_emptied', playerId: pid });
+    events.push({ type: 'mana_pool_emptied', playerId: pid });
   }
-  events.push({ kind: 'damage_cleared_at_cleanup' });
+  events.push({ type: 'damage_cleared_at_cleanup' });
   return events;
 };
 
@@ -60,7 +60,7 @@ const turnStartedFor = (state: GameState, justEntered: Step, fromStep: Step): Ga
   // turn rolls when cleanup → untap
   if (fromStep === 'cleanup' && justEntered === 'untap') {
     const newActive: PlayerId = otherPlayer(state, state.activePlayer);
-    return [{ kind: 'turn_started', turn: state.turn + 1, activePlayer: newActive }];
+    return [{ type: 'turn_started', turn: state.turn + 1, activePlayer: newActive }];
   }
   return [];
 };
@@ -69,7 +69,7 @@ const skippableEmptyDeclareSteps = (state: GameState, step: Step): GameEvent[] =
   if (step === 'declare_blockers' && state.combat.attackers.length === 0) {
     return [
       {
-        kind: 'step_advanced',
+        type: 'step_advanced',
         from: 'declare_blockers',
         to: 'combat_damage',
         turn: state.turn,
@@ -81,7 +81,7 @@ const skippableEmptyDeclareSteps = (state: GameState, step: Step): GameEvent[] =
 
 export const registerStepAdvanceSubscriber = (bus: EventBus): void => {
   bus.on('step_advanced', (state, event) => {
-    if (event.kind !== 'step_advanced') return [];
+    if (event.type !== 'step_advanced') return [];
     // First: any turn_started event for the *new* state
     const startedEvents = turnStartedFor(state, event.to, event.from);
     // Then: the intrinsic events for the new step

--- a/libs/engine-core/src/lib/engine/phases/combat.ts
+++ b/libs/engine-core/src/lib/engine/phases/combat.ts
@@ -51,21 +51,21 @@ const damageForPass = (state: GameState, pass: 'first_strike' | 'regular'): Game
     if (blockers.length === 0) {
       // Unblocked: damage to defending player
       events.push({
-        kind: 'damage_dealt',
+        type: 'damage_dealt',
         sourceCardId: attackerId,
         target: { kind: 'player', playerId: attack.defenderId },
         amount: attackerPT.power,
         combat: true,
       });
       events.push({
-        kind: 'life_changed',
+        type: 'life_changed',
         playerId: attack.defenderId,
         delta: -attackerPT.power,
         reason: 'damage',
       });
       if (hasKeyword(state, attackerId, 'lifelink')) {
         events.push({
-          kind: 'life_changed',
+          type: 'life_changed',
           playerId: state.cards[attackerId].controllerId,
           delta: attackerPT.power,
           reason: 'lifelink',
@@ -85,7 +85,7 @@ const damageForPass = (state: GameState, pass: 'first_strike' | 'regular'): Game
         const assigned = Math.min(remaining, lethalNeeded);
         if (assigned > 0) {
           events.push({
-            kind: 'damage_dealt',
+            type: 'damage_dealt',
             sourceCardId: attackerId,
             target: { kind: 'permanent', cardId: b.blockerId },
             amount: assigned,
@@ -93,7 +93,7 @@ const damageForPass = (state: GameState, pass: 'first_strike' | 'regular'): Game
           });
           if (hasKeyword(state, attackerId, 'lifelink')) {
             events.push({
-              kind: 'life_changed',
+              type: 'life_changed',
               playerId: state.cards[attackerId].controllerId,
               delta: assigned,
               reason: 'lifelink',
@@ -105,21 +105,21 @@ const damageForPass = (state: GameState, pass: 'first_strike' | 'regular'): Game
 
       if (aTrample && remaining > 0) {
         events.push({
-          kind: 'damage_dealt',
+          type: 'damage_dealt',
           sourceCardId: attackerId,
           target: { kind: 'player', playerId: attack.defenderId },
           amount: remaining,
           combat: true,
         });
         events.push({
-          kind: 'life_changed',
+          type: 'life_changed',
           playerId: attack.defenderId,
           delta: -remaining,
           reason: 'damage',
         });
         if (hasKeyword(state, attackerId, 'lifelink')) {
           events.push({
-            kind: 'life_changed',
+            type: 'life_changed',
             playerId: state.cards[attackerId].controllerId,
             delta: remaining,
             reason: 'lifelink',
@@ -136,7 +136,7 @@ const damageForPass = (state: GameState, pass: 'first_strike' | 'regular'): Game
         const bPT = ptOf(state, b.blockerId);
         if (bPT.power <= 0) continue;
         events.push({
-          kind: 'damage_dealt',
+          type: 'damage_dealt',
           sourceCardId: b.blockerId,
           target: { kind: 'permanent', cardId: attackerId },
           amount: bPT.power,
@@ -144,7 +144,7 @@ const damageForPass = (state: GameState, pass: 'first_strike' | 'regular'): Game
         });
         if (hasKeyword(state, b.blockerId, 'lifelink')) {
           events.push({
-            kind: 'life_changed',
+            type: 'life_changed',
             playerId: state.cards[b.blockerId].controllerId,
             delta: bPT.power,
             reason: 'lifelink',
@@ -165,5 +165,5 @@ export const computeCombatDamageEvents = (state: GameState): GameEvent[] => {
   // longer on the battlefield becomes a no-op via applyEvent's lookup).
   const fs = damageForPass(state, 'first_strike');
   const reg = damageForPass(state, 'regular');
-  return [...fs, { kind: 'combat_damage_marked' }, ...reg];
+  return [...fs, { type: 'combat_damage_marked' }, ...reg];
 };

--- a/libs/engine-core/src/lib/engine/stack/priority.ts
+++ b/libs/engine-core/src/lib/engine/stack/priority.ts
@@ -29,16 +29,16 @@ export const registerPriorityLoop = (bus: EventBus): void => {
   });
 
   bus.on('stack_item_resolved', (state) => [
-    { kind: 'priority_reset', to: state.activePlayer, reason: 'stack_changed' },
+    { type: 'priority_reset', to: state.activePlayer, reason: 'stack_changed' },
   ]);
 
   bus.on('step_advanced', (state) => [
-    { kind: 'priority_reset', to: state.activePlayer, reason: 'step_started' },
+    { type: 'priority_reset', to: state.activePlayer, reason: 'step_started' },
   ]);
 };
 
 const advanceStep = (state: GameState): GameEvent[] => {
   const idx = STEP_ORDER.indexOf(state.step);
   const to = STEP_ORDER[(idx + 1) % STEP_ORDER.length];
-  return [{ kind: 'step_advanced', from: state.step, to, turn: state.turn }];
+  return [{ type: 'step_advanced', from: state.step, to, turn: state.turn }];
 };

--- a/libs/engine-core/src/lib/engine/stack/resolve.ts
+++ b/libs/engine-core/src/lib/engine/stack/resolve.ts
@@ -17,7 +17,7 @@ import type { GameEvent } from '../events';
  */
 export const resolveStackItem = (state: GameState, item: StackItem): GameEvent[] => {
   const card = state.cards[item.cardId];
-  if (!card) return [{ kind: 'stack_item_resolved', stackItemId: item.id }];
+  if (!card) return [{ type: 'stack_item_resolved', stackItemId: item.id }];
   const def = getCardDefinition(card.definitionId);
 
   const events: GameEvent[] = [];
@@ -30,7 +30,7 @@ export const resolveStackItem = (state: GameState, item: StackItem): GameEvent[]
 
   if (isPermanent) {
     events.push({
-      kind: 'card_entered_zone',
+      type: 'card_entered_zone',
       cardId: card.id,
       from: 'stack',
       to: 'battlefield',
@@ -39,7 +39,7 @@ export const resolveStackItem = (state: GameState, item: StackItem): GameEvent[]
     // Instant / sorcery: run effect descriptors against current state, then graveyard.
     let targetIdx = 0;
     for (const effect of item.effects) {
-      const target = effect.kind === 'deal_damage_to_any' ? item.targets[targetIdx++] : undefined;
+      const target = effect.type === 'deal_damage_to_any' ? item.targets[targetIdx++] : undefined;
       const ctx = {
         state,
         casterId: item.controllerId,
@@ -51,13 +51,13 @@ export const resolveStackItem = (state: GameState, item: StackItem): GameEvent[]
       // Illegal-at-resolve errors are swallowed — analogous to fizzling.
     }
     events.push({
-      kind: 'card_entered_zone',
+      type: 'card_entered_zone',
       cardId: card.id,
       from: 'stack',
       to: 'graveyard',
     });
   }
 
-  events.push({ kind: 'stack_item_resolved', stackItemId: item.id });
+  events.push({ type: 'stack_item_resolved', stackItemId: item.id });
   return events;
 };

--- a/libs/engine-core/src/lib/engine/state-based-actions.ts
+++ b/libs/engine-core/src/lib/engine/state-based-actions.ts
@@ -15,9 +15,9 @@ export const checkStateBasedActions = (state: GameState): GameEvent[] => {
     if (!def.types.includes('creature')) continue;
     const toughness = (def.toughness ?? 0) + c.toughnessMod;
     if (c.damage > 0 && c.damage >= toughness) {
-      events.push({ kind: 'creature_died', cardId: id });
+      events.push({ type: 'creature_died', cardId: id });
       events.push({
-        kind: 'card_entered_zone',
+        type: 'card_entered_zone',
         cardId: id,
         from: 'battlefield',
         to: 'graveyard',
@@ -31,7 +31,7 @@ export const checkStateBasedActions = (state: GameState): GameEvent[] => {
     const p = state.players[pid];
     if (p.life <= 0 && !losers.has(pid)) {
       losers.add(pid);
-      events.push({ kind: 'player_lost', playerId: pid, reason: 'life' });
+      events.push({ type: 'player_lost', playerId: pid, reason: 'life' });
     }
   }
 
@@ -40,7 +40,7 @@ export const checkStateBasedActions = (state: GameState): GameEvent[] => {
   const allLosers = new Set([...state.losers, ...Array.from(losers)]);
   const survivors = state.playerOrder.filter((p) => !allLosers.has(p));
   if (allLosers.size > 0 && survivors.length <= 1) {
-    events.push({ kind: 'game_ended', winner: survivors[0] ?? null });
+    events.push({ type: 'game_ended', winner: survivors[0] ?? null });
   }
 
   return events;

--- a/libs/engine-core/src/lib/engine/validators/cast-creature.validator.ts
+++ b/libs/engine-core/src/lib/engine/validators/cast-creature.validator.ts
@@ -52,14 +52,14 @@ export const validateCastCreature = (
   };
 
   return ok<GameEvent[]>([
-    { kind: 'mana_spent', playerId: action.playerId, spent: action.manaSpent },
+    { type: 'mana_spent', playerId: action.playerId, spent: action.manaSpent },
     {
-      kind: 'card_entered_zone',
+      type: 'card_entered_zone',
       cardId: card.id,
       from: 'hand',
       to: 'stack',
       causedBy: action.playerId,
     },
-    { kind: 'spell_put_on_stack', item },
+    { type: 'spell_put_on_stack', item },
   ]);
 };

--- a/libs/engine-core/src/lib/engine/validators/cast-non-permanent-spell.ts
+++ b/libs/engine-core/src/lib/engine/validators/cast-non-permanent-spell.ts
@@ -52,7 +52,7 @@ export const castNonPermanentSpell = (
   }
 
   const effects = def.effects ?? [];
-  const targetCount = effects.filter((e) => e.kind === 'deal_damage_to_any').length;
+  const targetCount = effects.filter((e) => e.type === 'deal_damage_to_any').length;
   const targets = action.targets ?? [];
   if (targets.length < targetCount) {
     return err(`spell needs ${targetCount} target(s)`);
@@ -69,14 +69,14 @@ export const castNonPermanentSpell = (
   };
 
   return ok<GameEvent[]>([
-    { kind: 'mana_spent', playerId: action.playerId, spent: action.manaSpent },
+    { type: 'mana_spent', playerId: action.playerId, spent: action.manaSpent },
     {
-      kind: 'card_entered_zone',
+      type: 'card_entered_zone',
       cardId: card.id,
       from: 'hand',
       to: 'stack',
       causedBy: action.playerId,
     },
-    { kind: 'spell_put_on_stack', item },
+    { type: 'spell_put_on_stack', item },
   ]);
 };

--- a/libs/engine-core/src/lib/engine/validators/concede.validator.ts
+++ b/libs/engine-core/src/lib/engine/validators/concede.validator.ts
@@ -5,4 +5,4 @@ import type { GameState } from '../../model/game-state';
 import type { GameEvent } from '../events';
 
 export const validateConcede = (_state: GameState, action: Concede): Result<GameEvent[], string> =>
-  ok<GameEvent[]>([{ kind: 'player_lost', playerId: action.playerId, reason: 'concede' }]);
+  ok<GameEvent[]>([{ type: 'player_lost', playerId: action.playerId, reason: 'concede' }]);

--- a/libs/engine-core/src/lib/engine/validators/declare-attackers.validator.ts
+++ b/libs/engine-core/src/lib/engine/validators/declare-attackers.validator.ts
@@ -44,17 +44,17 @@ export const validateDeclareAttackers = (
     }
 
     if (!def.keywords.includes('vigilance')) {
-      events.push({ kind: 'permanent_tapped', cardId: id });
+      events.push({ type: 'permanent_tapped', cardId: id });
     }
     events.push({
-      kind: 'attacker_declared',
+      type: 'attacker_declared',
       attackerId: id,
       defenderId: defender,
     });
   }
 
   events.push({
-    kind: 'step_advanced',
+    type: 'step_advanced',
     from: 'declare_attackers',
     to: 'declare_blockers',
     turn: state.turn,

--- a/libs/engine-core/src/lib/engine/validators/declare-blockers.validator.ts
+++ b/libs/engine-core/src/lib/engine/validators/declare-blockers.validator.ts
@@ -50,14 +50,14 @@ export const validateDeclareBlockers = (
     }
 
     events.push({
-      kind: 'blocker_declared',
+      type: 'blocker_declared',
       blockerId: a.blockerId,
       attackerId: a.attackerId,
     });
   }
 
   events.push({
-    kind: 'step_advanced',
+    type: 'step_advanced',
     from: 'declare_blockers',
     to: 'combat_damage',
     turn: state.turn,

--- a/libs/engine-core/src/lib/engine/validators/pass-priority.validator.ts
+++ b/libs/engine-core/src/lib/engine/validators/pass-priority.validator.ts
@@ -12,5 +12,5 @@ export const validatePassPriority = (
     return err(`player ${action.playerId} does not have priority`);
   }
   const to = otherPlayer(state, action.playerId);
-  return ok<GameEvent[]>([{ kind: 'priority_passed', from: action.playerId, to }]);
+  return ok<GameEvent[]>([{ type: 'priority_passed', from: action.playerId, to }]);
 };

--- a/libs/engine-core/src/lib/engine/validators/play-land.validator.ts
+++ b/libs/engine-core/src/lib/engine/validators/play-land.validator.ts
@@ -33,9 +33,9 @@ export const validatePlayLand = (
   }
 
   return ok<GameEvent[]>([
-    { kind: 'land_played', playerId: action.playerId, cardId: card.id },
+    { type: 'land_played', playerId: action.playerId, cardId: card.id },
     {
-      kind: 'card_entered_zone',
+      type: 'card_entered_zone',
       cardId: card.id,
       from: 'hand',
       to: 'battlefield',

--- a/libs/engine-core/src/lib/engine/validators/tap-land-for-mana.validator.ts
+++ b/libs/engine-core/src/lib/engine/validators/tap-land-for-mana.validator.ts
@@ -30,9 +30,9 @@ export const validateTapLandForMana = (
     return err(`land cannot produce ${action.color}`);
   }
   return ok<GameEvent[]>([
-    { kind: 'permanent_tapped', cardId: card.id },
+    { type: 'permanent_tapped', cardId: card.id },
     {
-      kind: 'mana_produced',
+      type: 'mana_produced',
       playerId: action.playerId,
       color: action.color,
       amount: 1,


### PR DESCRIPTION
## Summary

- Renames the discriminator field on all `GameEvent` variants from `kind` to `type`, matching the convention established when `Action.kind` was renamed to `Action.type` in #71
- Renames `Effect.kind` → `type` on `DealDamageToAny`, `DrawCards`, and `GainLife` (and the registry lookup)
- Renames the derived type aliases: `GameEventKind` → `GameEventType`, `EffectKind` → `EffectType`
- Updates every consumer: `applyEvent` switch, `EventBus` internals, all validators, effect handlers, phase files, catalog entries, and the REPL printer

## Out of scope (intentionally unchanged)

- `EffectTarget.kind` (`'player'` / `'permanent'`) — different union, noted as out of scope in #73
- Wire-protocol discriminators on `ClientMessage` / `ServerMessage` — breaking change deferred

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — all 13 tests pass
- [x] `npm run format` — no changes
- [x] `npm run lint` — no new errors (pre-existing warnings only)

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)