### PR TITLE
add skipTurn() to REPL and fix auto-pass stuck bug

### DIFF
--- a/apps/engine-server/src/repl/index.ts
+++ b/apps/engine-server/src/repl/index.ts
@@ -134,6 +134,11 @@ const main = async (): Promise<void> => {
 
   let autoPass = false;
   let lastAutoPassedView: PlayerView | null = null;
+  /**
+   * When set, auto-pass runs through ALL steps (including declare_attackers /
+   * declare_blockers) until the turn number changes. Set by skipTurn().
+   */
+  let skipUntilTurn: number | null = null;
 
   const send = (msg: ClientMessage): void => {
     ws.send(JSON.stringify(msg));
@@ -148,18 +153,27 @@ const main = async (): Promise<void> => {
    *   - only when this player has priority
    *   - never during declare_attackers (you may want to attack) if you're the active player
    *   - never during declare_blockers if you're the defender
+   *   - the above two stops are bypassed while skipTurn() is active
    *
    * Stack items still trigger auto-pass — both REPLs with `auto(true)` will
    * keep cycling until the stack empties and the step advances.
    */
   const tryAutoPass = (): void => {
-    if (!autoPass) return;
     if (!view) return;
+    // Clear the turn-skip as soon as the turn rolls over.
+    if (skipUntilTurn !== null && view.turn !== skipUntilTurn) {
+      console.log(`turn ${skipUntilTurn} skipped`);
+      skipUntilTurn = null;
+    }
+    const skipping = skipUntilTurn !== null;
+    if (!autoPass && !skipping) return;
     if (view === lastAutoPassedView) return;
     if (view.status !== 'active') return;
     if (view.priorityPlayer !== playerId) return;
-    if (view.step === 'declare_attackers' && view.activePlayer === playerId) return;
-    if (view.step === 'declare_blockers' && view.activePlayer !== playerId) return;
+    if (!skipping) {
+      if (view.step === 'declare_attackers' && view.activePlayer === playerId) return;
+      if (view.step === 'declare_blockers' && view.activePlayer !== playerId) return;
+    }
     lastAutoPassedView = view;
     submit({ type: ActionType.PassPriority, playerId });
   };
@@ -168,6 +182,9 @@ const main = async (): Promise<void> => {
     const msg = JSON.parse(data.toString()) as ServerMessage;
     lastMessage = msg;
     if (msg.kind === 'state_sync' || msg.kind === 'event_batch') view = msg.view;
+    // A rejected action means our last auto-pass was refused; allow a retry so
+    // we don't get permanently stuck behind the lastAutoPassedView guard.
+    if (msg.kind === 'rejected_action') lastAutoPassedView = null;
     printIncoming(msg);
     tryAutoPass();
   });
@@ -405,6 +422,20 @@ const main = async (): Promise<void> => {
       tryAutoPass();
       return autoPass;
     },
+    /**
+     * Skip the rest of the current turn: auto-passes through every step
+     * (including declare_attackers and declare_blockers) until the turn
+     * number changes. Useful for quickly advancing past uninteresting turns
+     * during debugging. Does not affect the auto-pass setting for future turns.
+     */
+    skipTurn: () => {
+      const v = requireView();
+      if (!v) return;
+      skipUntilTurn = v.turn;
+      lastAutoPassedView = null;
+      console.log(`skipping turn ${v.turn}…`);
+      tryAutoPass();
+    },
     /** Print the helper list. */
     help: () => {
       console.log(`
@@ -429,6 +460,7 @@ Debugging:
   auto(true)                      — auto-pass priority (skips routine waits; stops at combat declares)
   auto(false)                     — turn off auto-pass
   auto()                          — show current state
+  skipTurn()                      — skip the rest of this turn (passes through all steps, including combat declares)
 `);
     },
   };


### PR DESCRIPTION
## Summary

- **`skipTurn()` helper**: passes through every step for the rest of the current turn — including `declare_attackers` and `declare_blockers` — and auto-resets when the turn number changes. Useful for fast-forwarding through uninteresting turns during debug sessions. Works independently of `auto(true)`.
- **Bug fix**: on a `rejected_action` response, `lastAutoPassedView` is now reset to `null`. Previously a rejected `PassPriority` would leave the dedup guard pointing at the current view, preventing any future auto-pass retries for that view and silently stalling the game.

## Test plan

- [ ] Start server (`npm run serve`) and open two REPL windows (`npm run repl:p1` / `npm run repl:p2`)
- [ ] Call `skipTurn()` in both windows; confirm the turn advances fully without stopping at `declare_attackers` or `declare_blockers`
- [ ] After `skipTurn()` completes, verify normal `auto(true)` behavior resumes (stops at combat declares on next turn)
- [ ] Verify `help()` lists `skipTurn()`
- [ ] All tests: `npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)